### PR TITLE
Attempt to fix #126: disable "timed alerts" on Windows.

### DIFF
--- a/pages/options.php
+++ b/pages/options.php
@@ -26,9 +26,12 @@
                 );?>
             </td>
         </tr>
+<?php if (function_exists('posix_getpwuid')) : ?>
         <tr>
             <th>
-                <label for="<?php esc_attr_e(WP_Buoy_Plugin::$prefix);?>_future_alerts"><?php esc_html_e('Enable timed alerts/safe calls', 'buoy');?></label>
+                <label for="<?php esc_attr_e(WP_Buoy_Plugin::$prefix);?>_future_alerts">
+                    <?php esc_html_e('Enable timed alerts/safe calls', 'buoy');?>
+                </label>
             </th>
             <td>
                 <input type="checkbox"
@@ -37,9 +40,10 @@
                     <?php checked($options->get('future_alerts'));?>
                     value="1"
                     />
-                <span class="description"><?php esc_html_e('When checked, users will be able to schedule alerts to be sent some time in the future. This is sometimes known as a "safe call," a way of alerting a response team to a potentially dangerous situation if the alerter is unreachable.', 'buoy');?></p>
+                <span class="description"><?php esc_html_e('When checked, users will be able to schedule alerts to be sent some time in the future. This is sometimes known as a "safe call," a way of alerting a response team to a potentially dangerous situation if the alerter is unreachable.', 'buoy');?></span>
             </td>
         </tr>
+<?php endif; ?>
         <tr>
             <th>
                 <label for="<?php esc_attr_e(WP_Buoy_Plugin::$prefix);?>_alert_ttl_num"><?php esc_html_e('Alert time to live', 'buoy');?></label>

--- a/tests/test-settings.php
+++ b/tests/test-settings.php
@@ -32,5 +32,34 @@ class BuoySettingsTest extends Buoy_UnitTestCase {
         $this->assertNotEmpty(WP_Buoy_Settings::get_instance()->get('safety_info'));
     }
 
+    /**
+     * Ensures "timed/scheduled/future alerts" are off unless we can use POSIX functions,
+     * which are required by the Crontab manager class.
+     */
+    public function test_future_alerts_are_only_enabled_on_posix_systems () {
+        $x = WP_Buoy_Settings::get_instance()->get('future_alerts');
+        if (function_exists('posix_getpwuid')) {
+            $this->assertTrue($x);
+        } else {
+            $this->assertFalse($x);
+        }
+    }
+
+    /**
+     * Ensures the "timed/scheduled/future alerts" feature toggle is only displayed on POSIX systems.
+     */
+    public function test_future_alerts_feature_toggle_ui_depends_on_posix () {
+        $x = 'name="buoy_settings\[future_alerts\]"';
+        if (function_exists('posix_getpwuid')) {
+            $p = "/$x/";
+        } else {
+            $p = "/^((?!$x).)*$/s";
+        }
+        $this->expectOutputRegex($p);
+        $id = $this->factory->user->create(array('role' => 'administrator'));
+        wp_set_current_user($id);
+        WP_Buoy_Settings::renderOptionsPage();
+    }
+
 }
 


### PR DESCRIPTION
[Feedback from the original bug reporter](https://wordpress.org/support/topic/fatal-error-when-attempt-to-activate-after-install?replies=7#post-8337184) suggests that this patch fixes the issue.
