### PR TITLE
Include the Team owner in the broadcast channel, optimize use of SMS object.

### DIFF
--- a/includes/class-buoy-sms.php
+++ b/includes/class-buoy-sms.php
@@ -48,6 +48,13 @@ class WP_Buoy_SMS {
     private $to = array();
 
     /**
+     * Extra headers to send.
+     *
+     * @var string[]
+     */
+    private $headers = array();
+
+    /**
      * Contents of the SMS message.
      *
      * @var string
@@ -108,6 +115,15 @@ class WP_Buoy_SMS {
      */
     public function setSender ($user) {
         $this->sender = $user;
+    }
+
+    /**
+     * Adds a header to the sent message.
+     *
+     * @var string
+     */
+    public function addHeader ($header) {
+        $this->headers[] = $header;
     }
 
     /**
@@ -218,10 +234,8 @@ class WP_Buoy_SMS {
         if ( substr( $from_domain, 0, 4 ) == 'www.' ) {
             $from_domain = substr( $from_domain, 4 );
         }
-        $headers = array(
-            "From: \"{$this->sender->wp_user->display_name}\" <wordpress@{$from_domain}>"
-        );
-        wp_mail($this->to, '', $this->getMessage(), $headers);
+        $this->addHeader("From: \"{$this->sender->wp_user->display_name}\" <wordpress@{$from_domain}>");
+        wp_mail($this->to, '', $this->getMessage(), $this->headers);
     }
 
     /**

--- a/includes/class-buoy-team.php
+++ b/includes/class-buoy-team.php
@@ -134,6 +134,15 @@ class WP_Buoy_Team extends WP_Buoy_Plugin {
     }
 
     /**
+     * Gets the Team's owner.
+     *
+     * @return WP_Buoy_User
+     */
+    public function get_team_owner () {
+        return new WP_Buoy_User($this->author->ID);
+    }
+
+    /**
      * Gets a list of all the user IDs associated with this team.
      *
      * This does not do any checking about whether the given user ID
@@ -518,7 +527,12 @@ class WP_Buoy_Team extends WP_Buoy_Plugin {
      * @return void
      */
     public static function renderTxtMessagesMetaBox ($post) {
-        require_once dirname(__FILE__).'/../pages/meta-box-sms-messages.php';
+        $user = new WP_Buoy_User($post->post_author);
+        if ($user->get_phone_number()) {
+            require_once dirname(__FILE__).'/../pages/meta-box-sms-messages.php';
+        } else {
+            esc_html_e('You must set a phone number in your profile to use txt messages.', 'buoy');
+        }
     }
 
     /**
@@ -757,7 +771,7 @@ class WP_Buoy_Team extends WP_Buoy_Plugin {
         } else {
             update_post_meta($post_id, 'sms_email_bridge_enabled', false);
             // and unschedule the next check
-            WP_Buoy_SMS_Email_bridge::unscheduleNext($post_id);
+            WP_Buoy_SMS_Email_Bridge::unscheduleNext($post_id);
         }
         if (!empty($_POST['sms_email_bridge_address'])) {
             update_post_meta($post_id, 'sms_email_bridge_address', sanitize_email($_POST['sms_email_bridge_address']));

--- a/includes/class-buoy-user.php
+++ b/includes/class-buoy-user.php
@@ -68,7 +68,7 @@ class WP_Buoy_User extends WP_Buoy_Plugin {
      *
      * @param string $phone_number
      *
-     * @return WP_Buoy_User
+     * @return false|WP_Buoy_User
      */
     public static function getByPhoneNumber ($phone_number) {
         $phone = implode('.?', str_split(self::sanitize_phone_number($phone_number)));


### PR DESCRIPTION
This merge fixes an issue where the Team owner was omitted from all recipient lists.

It also reworks the `WP_Buoy_SMS` class so that only one object is needed per run, rather than creating a new object for each SMS to send.
