### PR TITLE
Adds support for The People's Operator SMS provider.

### DIFF
--- a/includes/class-buoy-notification.php
+++ b/includes/class-buoy-notification.php
@@ -187,47 +187,4 @@ class WP_Buoy_Notification extends WP_Buoy_Plugin {
         $SMS->send();
     }
 
-    /**
-     * Utility function to return the domain name portion of a given
-     * telco's email-to-SMS gateway address.
-     *
-     * The returned string includes the prefixed `@` sign.
-     *
-     * @param string $provider A recognized `sms_provider` key.
-     *
-     * @see WP_Buoy_User_Settings::$default['sms_provider']
-     *
-     * @return string
-     */
-    public static function getEmailToSmsGatewayDomain ($provider) {
-        $provider_domains = array(
-            'AT&T' => '@txt.att.net',
-            'Alltel' => '@message.alltel.com',
-            'Boost Mobile' => '@myboostmobile.com',
-            'Cricket' => '@sms.mycricket.com',
-            'Metro PCS' => '@mymetropcs.com',
-            'Nextel' => '@messaging.nextel.com',
-            'Ptel' => '@ptel.com',
-            'Qwest' => '@qwestmp.com',
-            'Sprint' => array(
-                '@messaging.sprintpcs.com',
-                '@pm.sprint.com'
-            ),
-            'Suncom' => '@tms.suncom.com',
-            "The People's Operator (CDMA)" => '@messaging.sprintpcs.com',
-            "The People's Operator (GSM)" => '@mailmymobile.net',
-            'T-Mobile' => '@tmomail.net',
-            'Tracfone' => '@mmst5.tracfone.com',
-            'U.S. Cellular' => '@email.uscc.net',
-            'Verizon' => '@vtext.com',
-            'Virgin Mobile' => '@vmobl.com'
-        );
-        if (is_array($provider_domains[$provider])) {
-            $at_domain = array_rand($provider_domains[$provider]);
-        } else {
-            $at_domain = $provider_domains[$provider];
-        }
-        return $at_domain;
-    }
-
 }

--- a/includes/class-buoy-notification.php
+++ b/includes/class-buoy-notification.php
@@ -214,6 +214,8 @@ class WP_Buoy_Notification extends WP_Buoy_Plugin {
                 '@pm.sprint.com'
             ),
             'Suncom' => '@tms.suncom.com',
+            "The People's Operator (CDMA)" => '@messaging.sprintpcs.com',
+            "The People's Operator (GSM)" => '@mailmymobile.net',
             'T-Mobile' => '@tmomail.net',
             'Tracfone' => '@mmst5.tracfone.com',
             'U.S. Cellular' => '@email.uscc.net',

--- a/includes/class-buoy-settings.php
+++ b/includes/class-buoy-settings.php
@@ -104,7 +104,7 @@ class WP_Buoy_Settings {
      * is activated by a user without overwriting existing values.
      * 
      * @uses is_multisite()
-     * @uses wp_get_site()
+     * @uses get_sites()
      * @uses get_current_blog_id()
      * @uses switch_to_blog()
      * @uses WP_Buoy_Settings::activateSite()
@@ -115,12 +115,12 @@ class WP_Buoy_Settings {
      * @return void
      */
     public function activate ($network_wide) {
-        $sites = (is_multisite() && $network_wide) ? wp_get_sites() : array(array('blog_id' => get_current_blog_id()));
+        $sites = (is_multisite() && $network_wide) ? get_sites() : array((object) array('blog_id' => get_current_blog_id()));
         foreach ($sites as $site) {
             $restore = false;
-            if (get_current_blog_id() != $site['blog_id']) {
+            if (get_current_blog_id() != $site->blog_id) {
                 $restore = true;
-                switch_to_blog($site['blog_id']);
+                switch_to_blog($site->blog_id);
             }
             $this->activateSite();
             if ($restore) {

--- a/includes/class-buoy-sms-email-bridge.php
+++ b/includes/class-buoy-sms-email-bridge.php
@@ -47,6 +47,35 @@ class WP_Buoy_SMS_Email_Bridge {
     const backoff_max_seconds = 600; // 10 minutes
 
     /**
+     * The mapping of known SMS provider services and their public
+     * SMS-to-Email gateway domains.
+     *
+     * @var string[]
+     */
+    private static $sms_provider_to_email_map = array(
+        'AT&T' => 'txt.att.net',
+        'Alltel' => 'message.alltel.com',
+        'Boost Mobile' => 'myboostmobile.com',
+        'Cricket' => 'sms.mycricket.com',
+        'Metro PCS' => 'mymetropcs.com',
+        'Nextel' => 'messaging.nextel.com',
+        'Ptel' => 'ptel.com',
+        'Qwest' => 'qwestmp.com',
+        'Sprint' => array(
+            'messaging.sprintpcs.com',
+            'pm.sprint.com'
+        ),
+        'Suncom' => 'tms.suncom.com',
+        "The People's Operator (CDMA)" => 'messaging.sprintpcs.com',
+        "The People's Operator (GSM)" => 'mailmymobile.net',
+        'T-Mobile' => 'tmomail.net',
+        'Tracfone' => 'mmst5.tracfone.com',
+        'U.S. Cellular' => 'email.uscc.net',
+        'Verizon' => 'vtext.com',
+        'Virgin Mobile' => 'vmobl.com',
+    );
+
+    /**
      * Connects to an IMAP server with the settings from a given post.
      *
      * @param WP_Post $wp_post
@@ -80,6 +109,101 @@ class WP_Buoy_SMS_Email_Bridge {
      */
     public static function register () {
         add_action(self::hook, array(__CLASS__, 'run'), 10, 2);
+    }
+
+    /**
+     * Retrieves plain message text from MIME-encoded emails.
+     *
+     * @param Horde_Imap_Client_Data_Fetch $horde_fetched_data
+     *
+     * @return string
+     */
+    public static function getMessagePlainText ($horde_fetched_data) {
+        $plain_text_content = '';
+
+        $email_text = $horde_fetched_data->getFullMsg();
+        $mime_hdrs = Horde_Mime_Headers::parseHeaders($email_text);
+        $mime_part = Horde_Mime_Part::parseMessage($email_text);
+        $type_hdr = $mime_hdrs->getHeader('Content-Type');
+
+        // Horde_Mime_Part doesn't seem to deal well with MIME mail
+        // that is "multipart/related" so parse that ourselves.
+        if ($type_hdr && 'multipart/related' === $type_hdr->value_single) {
+            $boundary = $type_hdr->params['boundary'];
+            $lines = preg_split('/\R/', $mime_part->getContents());
+            $split_parts = array();
+            $i = -1;
+
+            // parse raw email source into MIME parts by boundary
+            foreach ($lines as $line) {
+                if (!empty($line) && false !== strpos($line, $boundary)) {
+                    $i = $i + 1;
+                    $line_type = 'header_lines';
+                    $split_parts[$i] = array(
+                        'header_lines' => array(),
+                        'body_lines'   => array(),
+                    );
+                    continue;
+                } else if ('header_lines' === $line_type && empty($line)) {
+                    $line_type = 'body_lines';
+                    continue;
+                }
+                $split_parts[$i][$line_type][] = $line;
+            }
+
+            // find the MIME part that has text/plain encoding
+            $part_key = false;
+            foreach ($split_parts as $i => $part) {
+                if(count(preg_grep('/Content-Type:\s*text\/plain/i', $part['header_lines']))) {
+                    $part_key = $i;
+                    break;
+                }
+            }
+
+            $text_part = $split_parts[$part_key];
+
+            // find if the body part is encoded
+            $encoding = array();
+            foreach ($text_part['header_lines'] as $line) {
+                preg_match('/Content-Transfer-Encoding:\s*(.*)$/i', $line, $encoding);
+                if (isset($encoding[1])) {
+                    $encoding = $encoding[1];
+                    break;
+                }
+            }
+
+            // decode if necessary
+            $lines = array();
+            foreach ($text_part['body_lines'] as $line) {
+                switch ($encoding) {
+                    case 'base64':
+                        $lines[] = base64_decode($line);
+                        break;
+                    default:
+                        $lines[] = $line;
+                            break;
+                }
+            }
+            $plain_text_content = implode('', $lines);
+        } else {
+            $body_id = $mime_part->findBody();
+            $body_part = $mime_part->getPart($body_id);
+            $plain_text_content = $body_part->getContents();
+        }
+
+        return $plain_text_content;
+    }
+
+    /**
+     * Parses email headers to retrieve the `From` mailbox address.
+     *
+     * @param Horde_Imap_Client_Data_Fetch $horde_fetched_data
+     *
+     * @return string
+     */
+    public static function getSenderNumber ($horde_fetched_data) {
+        $h = Horde_Mime_Headers::parseHeaders($horde_fetched_data->getFullMsg());
+        return $h->getHeader('From')->getAddressList(true)->first()->mailbox;
     }
 
     /**
@@ -156,18 +280,9 @@ class WP_Buoy_SMS_Email_Bridge {
                 ));
                 $SMS = new WP_Buoy_SMS();
                 foreach ($fetched as $data) {
-                    // get the body's plain text content
-                    $message = Horde_Mime_Part::parseMessage($data->getFullMsg());
-                    $body_id = $message->findBody();
-                    $part = $message->getPart($body_id);
-                    $txt = $part->getContents();
-
-                    // and get the sender's number
-                    $h = Horde_Mime_Headers::parseHeaders($data->getFullMsg());
-                    $from_phone = $h->getHeader('From')->getAddressList(true)->first()->mailbox;
-
+                    $txt = self::getMessagePlainText($data);
                     // strip any "+1" prefix
-                    $from_phone = preg_replace('/^\+1/', '', $from_phone);
+                    $from_phone = preg_replace('/^\+1/', '', self::getSenderNumber($data));
 
                     // forward the body text to each member of the team,
                     self::forward($SMS, $txt, $recipients,
@@ -303,6 +418,34 @@ class WP_Buoy_SMS_Email_Bridge {
         }
         $SMS->setSender($sender);
         $SMS->send();
+    }
+
+    /**
+     * Utility function to return the domain name portion of a given
+     * telco's email-to-SMS gateway address.
+     *
+     * The returned string includes the prefixed `@` sign.
+     *
+     * @param string $provider A recognized `sms_provider` key.
+     *
+     * @return string
+     */
+    public static function getEmailToSmsGatewayDomain ($provider) {
+        if (is_array(self::$sms_provider_to_email_map[$provider])) {
+            $domain = array_rand(self::$sms_provider_to_email_map[$provider]);
+        } else {
+            $domain = self::$sms_provider_to_email_map[$provider];
+        }
+        return '@'.$domain;
+    }
+
+    /**
+     * Gets the list of known SMS providers we can send email through.
+     *
+     * @return string[]
+     */
+    public static function getSmsProviders () {
+        return array_keys(self::$sms_provider_to_email_map);
     }
 
 }

--- a/includes/class-buoy-user-settings.php
+++ b/includes/class-buoy-user-settings.php
@@ -58,6 +58,8 @@ class WP_Buoy_User_Settings {
             'Qwest',
             'Sprint',
             'Suncom',
+            "The People's Operator (CDMA)",
+            "The People's Operator (GSM)",
             'T-Mobile',
             'Tracfone',
             'U.S. Cellular',

--- a/includes/class-buoy-user-settings.php
+++ b/includes/class-buoy-user-settings.php
@@ -46,26 +46,7 @@ class WP_Buoy_User_Settings {
         'installer_dismissed'       => false,
         'phone_number'              => '',
         'public_responder'          => false,
-        'sms_provider'              => array(
-            '',
-            'AT&T',
-            'Alltel',
-            'Boost Mobile',
-            'Cricket',
-            'Metro PCS',
-            'Nextel',
-            'Ptel',
-            'Qwest',
-            'Sprint',
-            'Suncom',
-            "The People's Operator (CDMA)",
-            "The People's Operator (GSM)",
-            'T-Mobile',
-            'Tracfone',
-            'U.S. Cellular',
-            'Verizon',
-            'Virgin Mobile'
-        )
+        'sms_provider'              => array(),
     );
 
     /**
@@ -80,6 +61,7 @@ class WP_Buoy_User_Settings {
             $user = get_userdata($user);
         }
         $this->user = $user;
+        $this->defaults['sms_provider'] = array_merge(array(''), WP_Buoy_SMS_Email_Bridge::getSmsProviders());
         $this->options = $this->get_options();
     }
 

--- a/includes/class-buoy-user.php
+++ b/includes/class-buoy-user.php
@@ -194,7 +194,7 @@ class WP_Buoy_User extends WP_Buoy_Plugin {
         $provider = $this->get_option('sms_provider');
 
         if (!empty($sms) && !empty($provider)) {
-            $sms_email = $sms . WP_Buoy_Notification::getEmailToSmsGatewayDomain($provider);
+            $sms_email = $sms . WP_Buoy_SMS_Email_Bridge::getEmailToSmsGatewayDomain($provider);
         }
 
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: meitar
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=TJLPJYXHSRBEE&lc=US&item_name=Better%20Angels%20Buoy&item_number=Better%20Angels%20Buoy&currency_code=USD&bn=PP%2dDonationsBF%3abtn_donate_SM%2egif%3aNonHosted
 Tags: community, emergency response, activism
-Requires at least: 4.4
+Requires at least: 4.6
 Tested up to: 4.6
 Stable tag: 0.3.0
 License: GPL-3


### PR DESCRIPTION
Minor refactoring to DRY up the email-to-SMS gateway domain knowledge is included, as is manual parsing for `multipart/related` MIME messages, which are used by The People's Operator. Unfortuantely, I was unable to figure out how to use the Horde MIME framework APIs to parse this sort of message content.
