### PR TITLE
Oops, remove debugging line. My bad.

### DIFF
--- a/includes/class-buoy-sms-email-bridge.php
+++ b/includes/class-buoy-sms-email-bridge.php
@@ -292,8 +292,7 @@ class WP_Buoy_SMS_Email_Bridge {
                         $sender,
                         array(
                             // Set the From header so as to create a thread for each Team
-                            //"From: \"{$sender->wp_user->display_name}\" <{$post->post_name}@".self::getThisServerDomain().'>',
-                            "From: \"{$sender->wp_user->display_name}\" <{$post->post_name}@somewhereelse.com>",
+                            "From: \"{$sender->wp_user->display_name}\" <{$post->post_name}@".self::getThisServerDomain().'>',
                             // This breaks Verizon's Email->SMS gateway. :(
                             // TODO: How do we get auto-reply addressing to work?
                             //'Reply-To: '.$post->sms_email_bridge_address


### PR DESCRIPTION
This fixes a mistake made in #153 where I failed to delete a line used for debugging. This makes zero behavioral difference thanks to having defensively coded `WP_Buoy_SMS->send()` but it was still a mistake.
