### PR TITLE
Hot fix for fatal error during first install caused by migration code.

### DIFF
--- a/buoy.php
+++ b/buoy.php
@@ -159,11 +159,6 @@ class WP_Buoy_Plugin {
 
         require_once 'includes/class-buoy-settings.php';
         WP_Buoy_Settings::get_instance()->activate($network_wide);
-
-        // TODO: Remove this after enough migrations.
-        require_once 'includes/class-buoy-user-settings.php';
-        require_once 'includes/class-buoy-team.php';
-        self::migrateDefaultTeamSettings();
     }
 
     /**
@@ -264,30 +259,6 @@ class WP_Buoy_Plugin {
     <p><a href="<?php print admin_url('plugin-install.php?tab=plugin-information&plugin=rest-api&TB_iframe=true&width=600&height=550')?>"><?php esc_html_e('Click here to install the REST API plugin.', 'buoy');?></a></p>
 </div>
 <?php
-    }
-
-    /**
-     * Updates old "default team" settings.
-     *
-     * This automatically moves the new "default team" internal data
-     * to the right places. Should be safe to remove after a few updates.
-     *
-     * @since 0.1.3
-     *
-     * @ignore This is purely a migration function, do not include in API docs.
-     */
-    public static function migrateDefaultTeamSettings () {
-        foreach (get_users() as $usr) {
-            $usropt = new WP_Buoy_User_Settings($usr);
-            $old_default = $usropt->get('default_team');
-            if ($old_default) {
-                $team = new WP_Buoy_Team($old_default);
-                $team->set_default();
-                $usropt
-                    ->delete('default_team')
-                    ->save();
-            }
-        }
     }
 
     /**


### PR DESCRIPTION
I'm not sure why this wasn't caught by the unit tests, since AFAIK the
test harness tries activating the plugin from a clean database. :(

This should be safe because WordPress plugin repository reports all
activate versions of Buoy are at 0.2.x, and this code was intended for
migrating from 0.1.x to 0.2.x.
