### PR TITLE
WIP: Compatibility and optimizations for WordPress 4.7 release

### DIFF
--- a/buoy.php
+++ b/buoy.php
@@ -107,13 +107,24 @@ class WP_Buoy_Plugin {
      * @return void
      */
     public static function initialize () {
-        // Make sure the WP REST API plugin is installed.
-        // We can remove this if block once that plugin is merged
-        // into WP Core.
-        require_once ABSPATH.'wp-admin/includes/plugin.php';
-        if (is_plugin_inactive('rest-api/plugin.php')) {
-            if (is_wp_error(activate_plugin('rest-api/plugin.php'))) {
-                self::install_plugin_dependency('rest-api');
+        // WordPress versions prior to 4.7 did not fully merge the
+        // WP REST API, on which we (partially) rely. In version 4.7,
+        // however, the REST API's important parts for our use case,
+        // the so-called "Content API" did indeed land in core. This
+        // means we no longer need to force-install it ourselves.
+        //
+        // See https://codex.wordpress.org/Version_4.7 highlights.
+        //
+        // For now, make sure the WP REST API plugin is installed and
+        // activated for users still running older WordPress versions.
+        // We can remove this check once enough Buoys update to v4.7.
+        global $wp_version;
+        if (version_compare('4.7', $wp_version) === 1) {
+            require_once ABSPATH.'wp-admin/includes/plugin.php';
+            if (is_plugin_inactive('rest-api/plugin.php')) {
+                if (is_wp_error(activate_plugin('rest-api/plugin.php'))) {
+                    self::install_plugin_dependency('rest-api');
+                }
             }
         }
 
@@ -194,15 +205,6 @@ class WP_Buoy_Plugin {
                 __('Buoy requires at least WordPress version %1$s. You have WordPress version %2$s.', 'buoy'),
                 $min_wp_version, $wp_version
             ));
-        }
-
-        // It turns out WordPress 4.5 did not include the WP REST API
-        // in core. :( SADNESS! We need it so let's make sure we have
-        // it installed. If we don't, let's install it automatically.
-        if (is_plugin_inactive('rest-api/plugin.php')) {
-            if (is_wp_error(activate_plugin('rest-api/plugin.php'))) {
-                self::install_plugin_dependency('rest-api');
-            }
         }
     }
 

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,6 @@
     },
     "minimum-stability": "stable",
     "suggest": {
-        "wpackagist-plugin/wp-pgp-encrypted-emails": "Offers additional security and privacy enhancements for email-based communication.",
-        "wpackagist-plugin/admin-language-per-user": "Enables end-user customization of the interface language."
+        "wpackagist-plugin/wp-pgp-encrypted-emails": "Offers additional security and privacy enhancements for email-based communication."
     }
 }

--- a/includes/class-buoy-helper.php
+++ b/includes/class-buoy-helper.php
@@ -28,13 +28,19 @@ class WP_Buoy_Helper {
      */
     public static function checkLocalPluginStatus () {
         $slugs = array(
-            'admin-language-per-user/admin-language-per-user.php',
-            'wp-pgp-encrypted-emails/wp-pgp-encrypted-emails.php'
+            'wp-pgp-encrypted-emails/wp-pgp-encrypted-emails.php',
         );
 
         global $wp_version;
+
         if (version_compare('4.5', $wp_version) > 0) {
             $slugs[] = 'rest-api/plugin.php';
+        }
+
+        // Suggest the following plugins if we are running WordPress
+        // versions earlier than 4.7.
+        if (version_compare('4.7', $wp_version) === 1) {
+            $slugs[] = 'admin-language-per-user/admin-language-per-user.php';
         }
 
         $plugins  = get_plugins();

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: meitar
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=TJLPJYXHSRBEE&lc=US&item_name=Better%20Angels%20Buoy&item_number=Better%20Angels%20Buoy&currency_code=USD&bn=PP%2dDonationsBF%3abtn_donate_SM%2egif%3aNonHosted
 Tags: community, emergency response, activism
 Requires at least: 4.6
-Tested up to: 4.6
+Tested up to: 4.7
 Stable tag: 0.3.2
 License: GPL-3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html


### PR DESCRIPTION
This pull request is for ensuring Buoy is ready for use in [WordPress version 4.7, released on December 6, 2016](https://codex.wordpress.org/Version_4.7).

The [WordPress 4.7 field guide](https://make.wordpress.org/core/2016/12/05/wordpress-4-7-field-guide/) provides an overview of the major changes in this new version. We should read through it, note any relevant changes, and update Buoy to address them.