### PR TITLE
Fix chat bug where responders repeatedly received old messages.

### DIFF
--- a/templates/comments-chat-room.js
+++ b/templates/comments-chat-room.js
@@ -62,7 +62,7 @@ var BUOY_CHAT_ROOM = (function () {
      */
     var pollForNewComments = function () {
         var url = api_base + '/comments&post=' + getPostId() + '&offset=' + getCommentCount()
-            + '&_wpnonce=' + wpApiSettings.nonce;
+            + '&_wpnonce=' + wpApiSettings.nonce + '&order=asc';
         jQuery.get(url, function (response) {
             if (response.length) {
                 appendComments(response);


### PR DESCRIPTION
This bug was only visible to users of browsers that did not support
HTML5 SSE and Buoy's chat room was therefore polling the WP REST API to
download new comments (chat messages) in the incident chat room. When a
user sent a new chat message, other users whose browsers were not
SSE-capable received the *first* chat message sent to the room instead
of the *newest* (latest/last) chat message sent to the room.

The bug was fixed by correctly ordering the result set of the API query.