### PR TITLE
Fixes #163, #140: Simpler SSE handling now that Firefox behaves better.

### DIFF
--- a/includes/class-buoy-alert.php
+++ b/includes/class-buoy-alert.php
@@ -964,7 +964,6 @@ class WP_Buoy_Alert extends WP_Buoy_Plugin {
 
             // Prevent server exhaustion by killing this thread eventually.
             if ((time() - $start_time) > (1 * MINUTE_IN_SECONDS)) {
-                print self::eventStreamMessage('', 'RESTART');
                 break;
             }
             sleep(1);

--- a/templates/comments-chat-room.php
+++ b/templates/comments-chat-room.php
@@ -31,12 +31,6 @@ header h1 { margin-top: 0; }
             <div id="new-comments-notice" class="updated notice is-dismissible">
                 <p><a href="#page-footer"><strong><?php esc_html_e('View new messages.', 'buoy');?></strong></a></p>
             </div>
-            <div class="notice error is-dismissible">
-                <p><?php print sprintf(
-                    esc_html__('Reconnecting&hellip;. (%1$sClick here to reconnect manually%2$s).', 'buoy'),
-                    '<a href="'.esc_url($_SERVER['HTTP_HOST'].$_SERVER['REQUEST_URI']).'">', '</a>'
-                );?></p>
-            </div>
             <ul class="media-list">
                 <?php $this->list_comments();?>
             </ul>


### PR DESCRIPTION
The explicit `RESTART` messages have been removed in this commit because
Firefox's behavior upon a server disconnect is now standards-compliant,
meaning it correctly reconnects automatically. The code handling the
`RESTART` messages has thus been moved to the `.onerror` handler.

This also means we no longer need to show the confusing "Click here to
manually reconnect" error notices to users.