### PR TITLE
Fixes #207: Avoid info disclosure even if PHP is insecurely configured.

### DIFF
--- a/includes/class-buoy-error-codes.php
+++ b/includes/class-buoy-error-codes.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Buoy Error Codes.
+ *
+ * Error codes for Buoy are defined in a class in this file.
+ *
+ * @package WordPress\Plugin\WP_Buoy_Plugin\Error_Codes
+ *
+ * @copyright Copyright (c) 2015-2016 by Meitar "maymay" Moscovitz
+ *
+ * @license https://www.gnu.org/licenses/gpl-3.0.en.html
+ */
+
+if (!defined('ABSPATH')) { exit; } // Disallow direct HTTP access.
+
+/**
+ * Error codes shared throughout Buoy.
+ *
+ * This class mimics Linux's implementation of POSIX.1. See errno(3).
+ * There's nothing special about these numbers except insofar as they
+ * will be familiar to POSIX nerds (and Linux kernel hackers). That
+ * said, they should not be confused with the actual system's errors.
+ */
+class Buoy_Error_Codes {
+
+    /**
+     * Error code for when a required system function is unavailable.
+     *
+     * @link https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/include/uapi/asm-generic/errno.h#n10
+     */
+    const ENOSYS = 38;
+
+}

--- a/includes/crontab-manager.php
+++ b/includes/crontab-manager.php
@@ -11,6 +11,8 @@
 
 if (!defined('ABSPATH')) { exit; } // Disallow direct HTTP access.
 
+require_once dirname(__FILE__).'/class-buoy-error-codes.php';
+
 /**
  * A simple helper class to manage crontab files.
  *
@@ -29,6 +31,8 @@ class Buoy_Crontab_Manager {
      * Constructor.
      *
      * @return void
+     *
+     * @throws RuntimeException
      */
     public function __construct () {
         if ($this->crontabExists()) {
@@ -65,9 +69,18 @@ class Buoy_Crontab_Manager {
      * Checks whether a crontab file exists.
      *
      * @return bool
+     *
+     * @throws RuntimeException
      */
     private function crontabExists () {
-        system('crontab -l >/dev/null 2>&1', $ret_val);
+        // suppress error/warning output
+        @system('crontab -l >/dev/null 2>&1', $ret_val);
+        if (!isset($ret_val) || !function_exists('posix_getpwuid')) {
+            throw new RuntimeException(
+                'Cannot determine presence or absence of cron (or POSIX system).',
+                Buoy_Error_Codes::ENOSYS
+            );
+        }
         return (0 === $ret_val) ? true : false;
     }
 

--- a/pages/options.php
+++ b/pages/options.php
@@ -26,7 +26,6 @@
                 );?>
             </td>
         </tr>
-<?php if (function_exists('posix_getpwuid')) : ?>
         <tr>
             <th>
                 <label for="<?php esc_attr_e(WP_Buoy_Plugin::$prefix);?>_future_alerts">
@@ -34,6 +33,7 @@
                 </label>
             </th>
             <td>
+<?php try { new Buoy_Crontab_Manager(); // only show if automatable ?>
                 <input type="checkbox"
                     id="<?php print esc_attr(WP_Buoy_Plugin::$prefix);?>_future_alerts"
                     name="<?php print esc_attr(WP_Buoy_Plugin::$prefix);?>_settings[future_alerts]"
@@ -41,9 +41,13 @@
                     value="1"
                     />
                 <span class="description"><?php esc_html_e('When checked, users will be able to schedule alerts to be sent some time in the future. This is sometimes known as a "safe call," a way of alerting a response team to a potentially dangerous situation if the alerter is unreachable.', 'buoy');?></span>
+<?php } catch (RuntimeException $e) { ?>
+                <div class="error notice">
+                    <p><?php esc_html_e('Timed Alerts are disabled because your system does not provide a safe means to implement them.', 'buoy');?></p>
+                </div>
+<?php } ?>
             </td>
         </tr>
-<?php endif; ?>
         <tr>
             <th>
                 <label for="<?php esc_attr_e(WP_Buoy_Plugin::$prefix);?>_alert_ttl_num"><?php esc_html_e('Alert time to live', 'buoy');?></label>

--- a/tests/test-settings.php
+++ b/tests/test-settings.php
@@ -32,34 +32,4 @@ class BuoySettingsTest extends Buoy_UnitTestCase {
         $this->assertNotEmpty(WP_Buoy_Settings::get_instance()->get('safety_info'));
     }
 
-    /**
-     * Ensures "timed/scheduled/future alerts" are off unless we can use POSIX functions,
-     * which are required by the Crontab manager class.
-     */
-    public function test_future_alerts_are_only_enabled_on_posix_systems () {
-        $x = WP_Buoy_Settings::get_instance()->get('future_alerts');
-        if (function_exists('posix_getpwuid')) {
-            $this->assertTrue($x);
-        } else {
-            $this->assertFalse($x);
-        }
-    }
-
-    /**
-     * Ensures the "timed/scheduled/future alerts" feature toggle is only displayed on POSIX systems.
-     */
-    public function test_future_alerts_feature_toggle_ui_depends_on_posix () {
-        $x = 'name="buoy_settings\[future_alerts\]"';
-        if (function_exists('posix_getpwuid')) {
-            $p = "/$x/";
-        } else {
-            $p = "/^((?!$x).)*$/s";
-        }
-        $this->expectOutputRegex($p);
-        $id = $this->factory->user->create(array('role' => 'administrator'));
-        wp_set_current_user($id);
-        WP_Buoy_Settings::renderOptionsPage();
-    }
-
 }
-


### PR DESCRIPTION
This commit addresses a potential information disclosure vulnerability
when PHP is configured to `display_errors` by suppressing the output of
PHP's warnings in the case where it would otherwise expose sensitive
information about the running system. This is done to protect the users
of a Buoy even in the face of a less experienced sysadmin who leaves
development configurations in effect on a production deployment.

Further, it enhances the mechanism by which the Timed Alert feature is
enabled away from a simplistic "is this a POSIX system?" guess and to
capability detection of whether or not the system has and can automate
its cron daemon. This logic has been concentrated in the crontab manager
class, which now throws a `RuntimeException` caught elsewhere. This also
enables the system to auto-correct its plugin settings, automatically
disabling the Timed Alert feature should a PHP-level configuration
change take place unbeknownst to the Buoy Admin.

Finally, the user interface of Buoy's Settings screen now explains why
or why not the feature is available on the running installation.

Old unit tests that were sort of but not really testing the earlier
implementation were removed. This is because the test is really an
integration test as it relies on the OS-level specifics and PHP's own
configuration values.